### PR TITLE
Fix the override file path for small ids.

### DIFF
--- a/generate_override.py
+++ b/generate_override.py
@@ -56,8 +56,8 @@ def path_for_override_file(display):
     """
     Determine the path where the override file should be written
     """
-    vendorpath = "DisplayVendorID-%0.2x" % display.vendor_id
-    productpath = "DisplayProductID-%0.2x" % display.product_id
+    vendorpath = "DisplayVendorID-%x" % display.vendor_id
+    productpath = "DisplayProductID-%x" % display.product_id
     return Path('Overrides') / vendorpath / productpath
 
 

--- a/test/test.py
+++ b/test/test.py
@@ -25,6 +25,15 @@ class TestEdidOverrides(unittest.TestCase):
         path = path_for_override_file(display)
         self.assertEqual(path, Path('Overrides/DisplayVendorID-10ac/DisplayProductID-d0fd'))
 
+    def test_path_for_override_file_product_1(self):
+        display = Display(
+            vendor_id = 2,
+            product_id = 1,
+            name = 'display',
+            edid = 'foobar'
+        )
+        path = path_for_override_file(display)
+        self.assertEqual(path, Path('Overrides/DisplayVendorID-2/DisplayProductID-1'))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As reported by @TomHeaven, the expected file path for product ids
<16 should not include an extra 0. I assume it's the same for the
vendor.

Behavior is unchanged for any other ids. The existing testcase
with the ids of my display still passes.

Fixes #10 